### PR TITLE
fix calling f with ref in undefined_behavior.md

### DIFF
--- a/content/other/safe_secure_rust_book/src/memory_safety/undefined_behavior.md
+++ b/content/other/safe_secure_rust_book/src/memory_safety/undefined_behavior.md
@@ -49,7 +49,7 @@ fn f(src: &Vec<i32>) -> Vec<i32> {
 
 pub fn main() {
     let src = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
-    let res = f(src);
+    let res = f(&src);
     println!("{:?}", res);
 }
 ```


### PR DESCRIPTION
The current code gives the wrong error - it complains about the f(src) - which should be f(&src), instead of complaining about the real bug here (i.e. using an uninitialized Vec)